### PR TITLE
Use "latest" tag for docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,7 @@ services:
     env_file: ./env.minio
     restart: always
   outline:
-    # TODO: remove hardcoded version
-    image: outlinewiki/outline:version-0.45.0
+    image: outlinewiki/outline:latest
     command: sh -c "yarn build && yarn sequelize db:migrate && yarn start"
     environment:
       - DATABASE_URL=postgres://user:pass@postgres:5432/outline


### PR DESCRIPTION
Only started publishing this tag as of a few releases ago, I don't think it was there when you originally created the script.