### PR TITLE
Adding PGSSLMODE=disable to env file (fixes #6)

### DIFF
--- a/generate_conf.sh
+++ b/generate_conf.sh
@@ -101,6 +101,9 @@ function create_env_files {
 
     env_replace PORT 3000 env.outline
     env_replace FORCE_HTTPS 'false' env.outline
+    
+    # Disable SSL for PostgreSQL: https://github.com/outline/outline/issues/1501
+    env_add PGSSLMODE disable env.outline
 
     # Setup datastore
     sed "s|outline-bucket|${BUCKET_NAME}|" -i data/nginx/http.conf.disabled


### PR DESCRIPTION
We need to make sure to disable SSL connection to the pgsql database by adding `PGSSLMODE=disable` as an env variable.

This PR also fixes #6 

See outline/outline#1501 for more information