### PR TITLE
Fixed docker-compose.yml for v0.48.0+

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     restart: always
   outline:
     image: outlinewiki/outline:latest
-    command: sh -c "yarn build && yarn sequelize db:migrate && yarn start"
+    command: sh -c "yarn sequelize:migrate --env production-ssl-disabled && yarn start"
     environment:
       - DATABASE_URL=postgres://user:pass@postgres:5432/outline
       - DATABASE_URL_TEST=postgres://user:pass@postgres:5432/outline-test


### PR DESCRIPTION
Due to changes within the docker image, its not required to build the server files everytime we start outline, we just need to migrate it (we need to add a variable that disables ssl for our database connection) and start the server afterwards