### PR TITLE
Certbot LetsEncrypt support for generating certificates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,6 @@ clean-data:
 	@bash generate_conf.sh delete_data
 
 clean: clean-docker clean-conf
+
+gen-https-cert: install
+	@bash generate_conf.sh init_data_dirs

--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,4 @@ clean-data:
 clean: clean-docker clean-conf
 
 gen-https-cert: install
-	@bash generate_conf.sh init_data_dirs
+	@bash generate_conf.sh gen_https_cert

--- a/Makefile
+++ b/Makefile
@@ -43,5 +43,5 @@ clean-data:
 
 clean: clean-docker clean-conf
 
-gen-https-cert: install
+gen-https-cert: install https
 	@bash generate_conf.sh gen_https_cert

--- a/data/nginx/http.conf.disabled
+++ b/data/nginx/http.conf.disabled
@@ -2,6 +2,10 @@ server {
   listen        80;
   client_max_body_size 100m;
 
+  location /.well-known/acme-challenge/ {
+    root /var/www/certbot;
+  }
+
   # Proxy requests to the bucket "outline" to MinIO server running on port 9000
   location /outline-bucket {
     include /etc/nginx/conf.d/include/proxy.conf;

--- a/data/nginx/https.conf.disabled
+++ b/data/nginx/https.conf.disabled
@@ -35,6 +35,10 @@ server {
 
     client_max_body_size 100m;
 
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
     # Proxy requests to the bucket "outline" to MinIO server running on port 9000
     location /outline-bucket {
         include /etc/nginx/conf.d/include/proxy.conf;

--- a/data/nginx/https_certbot.conf.disabled
+++ b/data/nginx/https_certbot.conf.disabled
@@ -1,0 +1,60 @@
+# modified from https://www.digitalocean.com/community/tutorials/how-to-create-a-self-signed-ssl-certificate-for-nginx-on-centos-7#step-3-configure-nginx-to-use-ssl
+server {
+    listen 443 http2 ssl;
+    listen [::]:443 http2 ssl;
+
+    ssl_certificate /etc/letsencrypt/live/main_cert/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/main_cert/privkey.pem;
+    ssl_dhparam /etc/ssl/certs/dhparam.pem;
+
+    ########################################################################
+    # from https://cipherli.st/                                            #
+    # and https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html #
+    ########################################################################
+
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
+    ssl_ecdh_curve secp384r1;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_tickets off;
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    resolver 8.8.8.8 8.8.4.4 valid=300s;
+    resolver_timeout 5s;
+    # Disable preloading HSTS for now.  You can use the commented out header line that includes
+    # the "preload" directive if you understand the implications.
+    #add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
+    add_header Strict-Transport-Security "max-age=63072000; includeSubdomains";
+    add_header X-Frame-Options DENY;
+    add_header X-Content-Type-Options nosniff;
+
+    ##################################
+    # END https://cipherli.st/ BLOCK #
+    ##################################
+
+    client_max_body_size 100m;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    # Proxy requests to the bucket "outline" to MinIO server running on port 9000
+    location /outline-bucket {
+        include /etc/nginx/conf.d/include/proxy.conf;
+        # minio has its own tls implementation
+        proxy_pass https://minio:9000;
+    }
+
+    # Proxy any other request to the application server running on port 9001
+    location / {
+        include /etc/nginx/conf.d/include/proxy.conf;
+        proxy_pass http://outline:3000;
+    }
+}
+
+
+server {
+    listen 80;
+    return 301 https://$host$request_uri;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,16 @@ services:
     volumes:
       - ./data/nginx/:/etc/nginx/conf.d/:z
       - ./data/certs/:/etc/ssl/certs/:z
+      - ./data/certbot/conf:/etc/letsencrypt:z
+      - ./data/certbot/www:/var/www/certbot:z
     restart: always
     depends_on:
       - outline
+      - certbot
+  certbot:
+    image: certbot/certbot
+    restart: unless-stopped
+    volumes:
+      - ./data/certbot/conf:/etc/letsencrypt:z
+      - ./data/certbot/www:/var/www/certbot:z
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"

--- a/generate_conf.sh
+++ b/generate_conf.sh
@@ -173,4 +173,14 @@ function init_data_dirs {
     mkdir -p data/minio_root/${AWS_S3_UPLOAD_BUCKET_NAME} data/pgdata
 }
 
+function gen_https_cert {
+    # get url from outline env
+    set -o allexport; source env.outline; set +o allexport
+    docker-compose run --rm --entrypoint "certbot certonly --webroot -w /var/www/certbot --agree-tos --force-renewal --cert-name main_cert -d ${HOST}" certbot
+    rm data/certs/public.crt
+    rm data/certs/private.key
+    ln -s data/certbot/conf/live/main_cert/fullchain.pem data/certs/public.crt 
+    ln -s data/certbot/conf/live/main_cert/privkey.pem data/certs/private.key
+}
+
 $*

--- a/generate_conf.sh
+++ b/generate_conf.sh
@@ -177,10 +177,14 @@ function gen_https_cert {
     # get url from outline env
     set -o allexport; source env.outline; set +o allexport
     docker-compose run --rm --entrypoint "certbot certonly --webroot -w /var/www/certbot --agree-tos --force-renewal --cert-name main_cert -d ${HOST}" certbot
-    rm data/certs/public.crt
-    rm data/certs/private.key
-    ln -s data/certbot/conf/live/main_cert/fullchain.pem data/certs/public.crt 
-    ln -s data/certbot/conf/live/main_cert/privkey.pem data/certs/private.key
+    pushd data/nginx
+    rm -f default.conf
+    ln -s https_certbot.conf.disabled default.conf
+    popd
+    # rm data/certs/public.crt
+    # rm data/certs/private.key
+    # ln -s data/certbot/conf/live/main_cert/fullchain.pem data/certs/public.crt 
+    # ln -s data/certbot/conf/live/main_cert/privkey.pem data/certs/private.key
 }
 
 $*


### PR DESCRIPTION
I have added a Makefile command `gen-https-cert` which does the following:
 - Runs the `certbot` container separately
 -  Generate new certificate for `$host` domain
 - Changes the Nginx config to `https_certbot.conf.disabled` which points to new certificate location

The `certbot` container automatically checks for certificate renewal every 12 hours via it's entrypoint command.

So, now on a server instance, following commands will result in running Outline with LetsEncrypt verified certificates:
```
git clone https://github.com/chsasank/outline-wiki-docker-compose.git
cd outline-wiki-docker-compose
make install
make https
make gen-https-cert
make stop
make start
```