### PR TITLE
Fix proxy to allow websocket connections

### DIFF
--- a/data/nginx/include/proxy.conf
+++ b/data/nginx/include/proxy.conf
@@ -6,5 +6,6 @@ proxy_set_header Host $http_host;
 proxy_connect_timeout 300;
 # Default is HTTP/1, keepalive is only enabled in HTTP/1.1
 proxy_http_version 1.1;
-proxy_set_header Connection "";
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Connection "upgrade";
 chunked_transfer_encoding off;


### PR DESCRIPTION
Changing the config to this is required for websockets to work for me, I assume this is the case most of the time so I figure this change would be helpful unless there's something about this I'm missing.